### PR TITLE
NAS-130977 / 24.04.2.1 / bump 23.12.1 -> 23.12.2

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 VERSION=23.12
-REVISION=1
+REVISION=2
 
 
 wget http://deb.debian.org/debian/pool/main/o/openseachest/openseachest_$VERSION-$REVISION.debian.tar.xz


### PR DESCRIPTION
23.12.1 was removed so we need to bump to 23.12.2 to allow 24.04.2.1 hotfix to build.